### PR TITLE
Added support for lowercase hexadecimal strings

### DIFF
--- a/GoPaddy.go
+++ b/GoPaddy.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"bufio"
-	"log"
 	"os"
-
-	"net/http"
 
 	"github.com/mattn/go-isatty"
 )

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ OPTIONS:
 	This option is used in conjunction with -r option (see below)
 	Supported values:
 		b64 (standard base64) *default*
+		lhex (lowercase hex)
 
 -r
 

--- a/args.go
+++ b/args.go
@@ -42,6 +42,7 @@ flag(-e)
 	This option is used in conjunction with flag(-r) option (see below)
 	Supported values:
 		b64 (standard base64) *default*
+		lhex (lowercase hex)
 
 flag(-r)
 	Character replacement rules that vulnerable server applies
@@ -247,6 +248,8 @@ func parseArgs() (ok bool, cipher *string) {
 		if err != nil {
 			argError("-r", err.Error())
 		}
+	case "lhex":
+		config.encoder, err = createLowerHexEncoderDecoder(*replacements)
 	default:
 		argError("-e", "Unsupported encoding specified")
 	}


### PR DESCRIPTION
Hello,

I've added support for lowercase hexadecimal encoded strings. I've kept the "replacement" functionality, even though I'm not sure it's really useful in the case of hex strings.

Cheers,
Boris